### PR TITLE
Fixed QR-codes with non-latin chars via API version update.

### DIFF
--- a/GroupDocs.Total.WebForms.Test/app.config
+++ b/GroupDocs.Total.WebForms.Test/app.config
@@ -7,10 +7,6 @@
         <bindingRedirect oldVersion="0.0.0.0-1.5.2.14234" newVersion="1.5.2.14234" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-5.2.6.0" newVersion="5.2.6.0" />
       </dependentAssembly>
@@ -33,6 +29,10 @@
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Owin.Security.Cookies" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-3.0.1.0" newVersion="3.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/GroupDocs.Total.WebForms.csproj
+++ b/src/GroupDocs.Total.WebForms.csproj
@@ -59,8 +59,8 @@
     <Reference Include="GroupDocs.Metadata, Version=20.1.0.0, Culture=neutral, PublicKeyToken=716fcc553a201e56, processorArchitecture=MSIL">
       <HintPath>..\packages\GroupDocs.Metadata.20.1.0\lib\net20\GroupDocs.Metadata.dll</HintPath>
     </Reference>
-    <Reference Include="GroupDocs.Signature, Version=20.3.0.0, Culture=neutral, PublicKeyToken=716fcc553a201e56, processorArchitecture=MSIL">
-      <HintPath>..\packages\GroupDocs.Signature.20.3.0\lib\net20\GroupDocs.Signature.dll</HintPath>
+    <Reference Include="GroupDocs.Signature, Version=20.4.0.0, Culture=neutral, PublicKeyToken=716fcc553a201e56, processorArchitecture=MSIL">
+      <HintPath>..\packages\GroupDocs.Signature.20.4.0\lib\net20\GroupDocs.Signature.dll</HintPath>
     </Reference>
     <Reference Include="GroupDocs.Viewer, Version=20.4.0.0, Culture=neutral, PublicKeyToken=716fcc553a201e56, processorArchitecture=MSIL">
       <HintPath>..\packages\GroupDocs.Viewer.20.4.0\lib\net20\GroupDocs.Viewer.dll</HintPath>
@@ -70,6 +70,9 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System" />
     <Reference Include="System.Data" />
@@ -126,10 +129,6 @@
       <Private>True</Private>
       <HintPath>..\packages\Antlr.3.4.1.9004\lib\Antlr3.Runtime.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json">
-      <Private>True</Private>
-      <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.AspNet.Web.Optimization.WebForms">
       <Private>True</Private>
       <HintPath>..\packages\Microsoft.AspNet.Web.Optimization.WebForms.1.1.3\lib\net45\Microsoft.AspNet.Web.Optimization.WebForms.dll</HintPath>
@@ -142,9 +141,6 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
     <Reference Include="System.Web.Http.WebHost">
       <HintPath>..\packages\Microsoft.AspNet.WebApi.WebHost.5.2.3\lib\net45\System.Web.Http.WebHost.dll</HintPath>
     </Reference>

--- a/src/Products/Common/Entity/Web/LoadDocumentEntity.cs
+++ b/src/Products/Common/Entity/Web/LoadDocumentEntity.cs
@@ -9,7 +9,7 @@ namespace GroupDocs.Total.WebForms.Products.Common.Entity.Web
         [JsonProperty]
         private string guid;
 
-        ///list of pages        
+        ///list of pages
         [JsonProperty]
         private List<PageDescriptionEntity> pages = new List<PageDescriptionEntity>();
 

--- a/src/Web.config
+++ b/src/Web.config
@@ -93,11 +93,7 @@
     </handlers>
   </system.webServer>
   <runtime>
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">			
-      <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" culture="neutral" publicKeyToken="30ad4fe6b2a6aeed" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
-      </dependentAssembly>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="WebGrease" culture="neutral" publicKeyToken="31bf3856ad364e35" />
         <bindingRedirect oldVersion="0.0.0.0-1.5.2.14234" newVersion="1.5.2.14234" />
@@ -134,6 +130,10 @@
         <assemblyIdentity name="Aspose.PDF" publicKeyToken="716fcc553a201e56" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-18.5.0.0" newVersion="18.5.0.0" />
         <publisherPolicy apply="no" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/packages.config
+++ b/src/packages.config
@@ -6,7 +6,7 @@
   <package id="GroupDocs.Conversion" version="20.3.0" targetFramework="net45" />
   <package id="GroupDocs.Editor" version="20.2.0" targetFramework="net45" />
   <package id="GroupDocs.Metadata" version="20.1.0" targetFramework="net45" />
-  <package id="GroupDocs.Signature" version="20.3.0" targetFramework="net45" />
+  <package id="GroupDocs.Signature" version="20.4.0" targetFramework="net45" />
   <package id="GroupDocs.Viewer" version="20.4.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.Cors" version="5.2.6" targetFramework="net45" />
   <package id="Microsoft.AspNet.FriendlyUrls" version="1.0.2" targetFramework="net45" />
@@ -25,7 +25,7 @@
   <package id="Microsoft.Net.Compilers" version="1.0.0" targetFramework="net45" developmentDependency="true" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
   <package id="Modernizr" version="2.6.2" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net45" />
   <package id="Node-Kit" version="11.1.0.1" targetFramework="net45" />
   <package id="Respond" version="1.2.0" targetFramework="net45" />
   <package id="WebGrease" version="1.5.2" targetFramework="net45" />


### PR DESCRIPTION
Replicated changes from https://github.com/groupdocs-signature/GroupDocs.Signature-for-.NET-MVC/pull/33.