### PR TITLE
Update library API version to fix summary navigation.

### DIFF
--- a/src/GroupDocs.Total.WebForms.csproj
+++ b/src/GroupDocs.Total.WebForms.csproj
@@ -65,8 +65,8 @@
     <Reference Include="GroupDocs.Signature, Version=20.4.0.0, Culture=neutral, PublicKeyToken=716fcc553a201e56, processorArchitecture=MSIL">
       <HintPath>..\packages\GroupDocs.Signature.20.4.0\lib\net20\GroupDocs.Signature.dll</HintPath>
     </Reference>
-    <Reference Include="GroupDocs.Viewer, Version=20.7.0.0, Culture=neutral, PublicKeyToken=716fcc553a201e56, processorArchitecture=MSIL">
-      <HintPath>..\packages\GroupDocs.Viewer.20.7.0\lib\net20\GroupDocs.Viewer.dll</HintPath>
+    <Reference Include="GroupDocs.Viewer, Version=20.11.0.0, Culture=neutral, PublicKeyToken=716fcc553a201e56, processorArchitecture=MSIL">
+      <HintPath>..\packages\GroupDocs.Viewer.20.11.0\lib\net20\GroupDocs.Viewer.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.0\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>

--- a/src/packages.config
+++ b/src/packages.config
@@ -8,7 +8,7 @@
   <package id="GroupDocs.Metadata" version="20.7.0" targetFramework="net45" />
   <package id="GroupDocs.Search" version="20.4.0" targetFramework="net45" />
   <package id="GroupDocs.Signature" version="20.4.0" targetFramework="net45" />
-  <package id="GroupDocs.Viewer" version="20.7.0" targetFramework="net45" />
+  <package id="GroupDocs.Viewer" version="20.11.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.Cors" version="5.2.6" targetFramework="net45" />
   <package id="Microsoft.AspNet.FriendlyUrls" version="1.0.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.FriendlyUrls.Core" version="1.0.2" targetFramework="net45" />


### PR DESCRIPTION
Replicated changes from: https://github.com/groupdocs-viewer/GroupDocs.Viewer-for-.NET-WebForms/pull/79.